### PR TITLE
update to latest egui_glow

### DIFF
--- a/payload/Cargo.toml
+++ b/payload/Cargo.toml
@@ -32,10 +32,10 @@ tracing-android = "0.2.0"
 proc-maps = "0.3.1"
 
 [dependencies]
-glow = "0.12.2"
+glow = "0.13.1"
 
-egui = { version = "0.22.0" }
-egui_glow = "0.22.0"
+egui = { version = "0.26.1" }
+egui_glow = "0.26.1"
 
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"

--- a/payload/src/lib.rs
+++ b/payload/src/lib.rs
@@ -196,8 +196,9 @@ impl PayloadContext {
     fn render(&mut self) {
         let egui::FullOutput {
             platform_output: _platform_output,
-            repaint_after: _repaint_after,
             textures_delta,
+            pixels_per_point,
+            viewport_output: _viewport_output,
             shapes,
         } = self.egui_ctx.run(Default::default(), |ui| {
             egui::SidePanel::left("my_side_panel").show(ui, |ui| {
@@ -211,20 +212,14 @@ impl PayloadContext {
         let shapes = std::mem::take(&mut self.shapes);
         let mut textures_delta = std::mem::take(&mut self.textures_delta);
 
-        for (id, image_delta) in textures_delta.set {
-            self.painter.set_texture(id, &image_delta);
-        }
-
-        let clipped_primitives = self.egui_ctx.tessellate(shapes);
-        self.painter.paint_primitives(
+        let clipped_primitives = self.egui_ctx.tessellate(shapes,pixels_per_point);
+        self.painter.paint_and_update_textures(
             self.dimensions,
             self.egui_ctx.pixels_per_point(),
             &clipped_primitives,
+            &textures_delta,
         );
 
-        for id in textures_delta.free.drain(..) {
-            self.painter.free_texture(id);
-        }
     }
 }
 


### PR DESCRIPTION
looks like some apis are changed in egui_glow,  (less api calls now) this commit fixes wrong parameters to paint_and_update_textures function and removes unneccesary calls 
[paint_and_update_textures](https://github.com/emilk/egui/blob/d99fabaef535fb6e5d0dc907fa85418935bece7e/crates/egui_glow/src/painter.rs#L356)